### PR TITLE
Bump matplotlib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 pytest==5.3.2
 pyyaml
 seaborn==0.10.0.rc0
-matplotlib==3.0.0
+matplotlib>=3.3
 sklearn
 pytabix==0.1
 sphinx==2.1.1 # documentation


### PR DESCRIPTION
v3.0.0 causes errors on import.

```
ImportError: cannot import name 'get_backend' from partially initialized module 'matplotlib' (most likely due to a circular import)
```

All tests pass with v3.3.4.