### PR TITLE
Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ _static/
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info
 /*.egg
+
+epitome/test/data/
+target/pytest-reports/

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ check_build_reqs:
                 || ( printf "$(redpip)Build requirements are missing. Run 'make prepare' to install them.$(normal)" ; false )
 
 test: check_build_reqs
-	$(python) -m pytest -vv --junitxml target/pytest-reports/tests.xml $(tests)
+	$(python) -m pytest -o junit_family=xunit2 -vv --junitxml target/pytest-reports/tests.xml $(tests)
 
 check_clean_working_copy:
 	@printf "$(green)Checking if your working copy is clean ...$(normal)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 numpy
-pytest==5.3.2
+pytest == 5.3.2
 pyyaml
-seaborn==0.10.0.rc0
-matplotlib>=3.3
+seaborn >= 0.11.2
+matplotlib >= 3.4.3
 sklearn
-pytabix==0.1
-gast==0.3.3
+pytabix == 0.1
+gast == 0.4.0
 tqdm
-pyranges>=0.0.84
-h5sparse==0.0.5
-setuptools==52.0.0
+pyranges >= 0.0.104
+h5sparse >= 0.1.0
+setuptools >= 57.4.0

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,7 @@ if 'tensorflow' not in installed:
     warnings.warn(message)
 
     # append tensorflow or tensorflow-gpu to reqs
-    # need nightly build to work with tensorflow probability
-    TENSORFLOW_VERSION="2.3.0"
+    TENSORFLOW_VERSION="2.6.0"
 
     try:
         subprocess.check_output(["nvidia-smi", "-L"])
@@ -53,7 +52,7 @@ if 'tensorflow' not in installed:
     reqs.append(tf_req)
 
 # Cython must be installed before pyranges
-err = subprocess.call(["pip","install","cython"])
+err = subprocess.call(["pip", "install", "cython"])
 if err != 0:
     raise Exception("Installing cython failed with error %i" % err)
 
@@ -77,7 +76,8 @@ setup(
         # Python versions supported
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
     license="Apache License, Version 2.0",
     keywords='ENCODE ChIP-seq_peaks prediction histone transcription_factor',


### PR DESCRIPTION
- Support `python 3.9`. Update dependencies.
- Fix `pytest` warning
- Ignore test data and reports

Closes #50.
Closes #82.